### PR TITLE
chore: configure pre-commit and code style

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+# Конфигурация pre-commit для проверки стиля кода
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -1,8 +1,8 @@
 """Оркестратор приложения."""
 
-from core.media_proc import MediaProcessor
 from core.asr_whisper import transcribe
 from core.diarization import diarize
+from core.media_proc import MediaProcessor
 from core.postprocess import merge_results
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,16 @@
+# Общие настройки инструментов проверки кода
+[flake8]
+max-line-length = 88
+extend-ignore = E203, W503
+
+[isort]
+profile = black
+line_length = 88
+src_paths = core,gui,utils,tests
+
+[black]
+line-length = 88
+
+[tool:pytest]
+addopts = -q
+testpaths = tests

--- a/tests/test_export_srt_md.py
+++ b/tests/test_export_srt_md.py
@@ -3,8 +3,8 @@
 import os
 import tempfile
 
-from core.export_srt import export_srt
 from core.export_md import export_md
+from core.export_srt import export_srt
 
 
 def _check_export(func, suffix: str) -> None:


### PR DESCRIPTION
## Summary
- add pre-commit with black, isort and flake8
- configure flake8, isort, black and pytest in setup.cfg
- sort imports to satisfy style checks

## Testing
- `python -m pre_commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a88df403288320b1ff74d1ed6ab43a