### PR TITLE
Реализация пайплайна оркестратора и связь с GUI

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,12 +1,19 @@
 """Точка входа приложения."""
 
+from PyQt5.QtWidgets import QApplication
+
 from core.orchestrator import Orchestrator
+from gui.window import MainWindow
 
 
 def main() -> None:
-    """Запускает основной процесс приложения."""
-    orchestrator = Orchestrator()
-    orchestrator.run()
+    """Создаёт GUI и связывает его с оркестратором."""
+    app = QApplication([])
+    window = MainWindow()
+    orchestrator = Orchestrator(on_done=window.set_done, on_error=window.set_error)
+    window.file_dropped.connect(orchestrator.run)
+    window.show()
+    app.exec_()
 
 
 if __name__ == "__main__":

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -1,19 +1,60 @@
 """Оркестратор приложения."""
 
+from __future__ import annotations
+
+from typing import Callable, Optional
+
 from core.asr_whisper import transcribe
 from core.diarization import diarize
 from core.media_proc import MediaProcessor
 from core.postprocess import merge_results
+from core.export_txt import export_txt
+from utils.paths import build_output_path
 
 
 class Orchestrator:
     """Связывает все этапы обработки файла."""
 
-    def run(self) -> None:
-        """Запускает пайплайн обработки."""
-        # Заглушка пайплайна
-        media = MediaProcessor()
-        audio_path = media.extract_audio("input")
-        text_segments = transcribe(audio_path)
-        speaker_segments = diarize(audio_path)
-        merge_results(text_segments, speaker_segments)
+    def __init__(
+        self,
+        on_done: Optional[Callable[[str], None]] = None,
+        on_error: Optional[Callable[[str], None]] = None,
+    ) -> None:
+        """Создаёт оркестратор.
+
+        :param on_done: колбэк при успешном завершении.
+        :param on_error: колбэк при возникновении ошибки.
+        """
+        self._on_done = on_done
+        self._on_error = on_error
+
+    def run(self, src_path: str) -> Optional[str]:
+        """Запускает пайплайн обработки файла.
+
+        1. Извлекает аудио.
+        2. Транскрибирует речь.
+        3. Выполняет диаризацию.
+        4. Объединяет результаты.
+        5. Сохраняет итоговый текст.
+
+        :param src_path: путь к исходному медиафайлу.
+        :return: путь к итоговому файлу или ``None`` при ошибке.
+        """
+        try:
+            media = MediaProcessor()
+            audio_path = media.extract_audio(src_path)
+
+            text_segments = transcribe(audio_path)
+            speaker_segments = diarize(audio_path)
+            merged_lines = merge_results(text_segments, speaker_segments)
+
+            result_path = build_output_path(src_path)
+            export_txt(merged_lines, result_path)
+
+            if self._on_done:
+                self._on_done(result_path)
+            return result_path
+        except Exception as error:  # noqa: BLE001
+            if self._on_error:
+                self._on_error(str(error))
+            return None

--- a/gui/window.py
+++ b/gui/window.py
@@ -46,9 +46,15 @@ class MainWindow(QWidget):
         """Отображает процесс обработки файла."""
         self._status_label.setText(messages.PROCESSING_MESSAGE)
 
-    def set_done(self) -> None:
-        """Отображает успешное завершение обработки."""
-        self._status_label.setText(messages.DONE_MESSAGE)
+    def set_done(self, result_path: Optional[str] = None) -> None:
+        """Отображает успешное завершение обработки.
+
+        :param result_path: путь к итоговому файлу.
+        """
+        message = messages.DONE_MESSAGE
+        if result_path:
+            message = f"{message}: {result_path}"
+        self._status_label.setText(message)
 
     def set_error(self, message: Optional[str] = None) -> None:
         """Отображает сообщение об ошибке.


### PR DESCRIPTION
## Изменения
- Реализован полный пайплайн в `Orchestrator` с возвратом пути к результату и колбэками.
- Дополнено окно GUI выводом пути к итоговому файлу.
- Настроено взаимодействие GUI и оркестратора через сигнал/слот.

## Тестирование
- `pre-commit run --files core/orchestrator.py gui/window.py app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a89ea676bc8320835300bb47754304