### PR TITLE
Добавить CPU-репозиторий PyTorch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch==2.8.0
 PyQt5
 ffmpeg-python
 openai-whisper


### PR DESCRIPTION
## Summary
- добавить в requirements.txt ссылку на CPU-репозиторий PyTorch
- зафиксировать версию `torch==2.8.0`

## Testing
- `pytest`
- `pip install --dry-run -r requirements.txt` *(403 Forbidden при обращении к download.pytorch.org; GPU-пакеты остаются в текущем окружении)*


------
https://chatgpt.com/codex/tasks/task_e_68a8ae427ae88320bfa5562de241823c