### PR TITLE
Limit PyQt5 installation to supported Python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,13 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11"]
     steps:
       - name: Получение кода
         uses: actions/checkout@v4
       - name: Установка Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
       - name: Установка зависимостей
         run: |
           pip install -r requirements.txt -r requirements-dev.txt

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,5 +1,5 @@
 # Используем официальный образ Python
-FROM python:3.13-slim
+FROM python:3.11-slim
 
 # Установка системных зависимостей
 RUN apt-get update \

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
-PyQt5
+PyQt5; python_version < "3.12"
 pytest
 pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.8.0
-PyQt5
+PyQt5; python_version < "3.12"
 ffmpeg-python
 openai-whisper
 pyannote.audio


### PR DESCRIPTION
## Summary
- fix CI to run on Python 3.11
- limit PyQt5 installation to Python < 3.12 in requirements
- set Dockerfile.ci to Python 3.11 base image

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8cdd1c5e08320a3ecde93d566099f