### PR TITLE
Исправление build_output_path и добавление теста

### DIFF
--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,16 @@
+"""Тесты для модуля utils.paths."""
+
+from pathlib import Path
+import sys
+
+# Добавляем корень проекта в путь поиска модулей.
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from utils.paths import build_output_path
+
+
+def test_build_output_path_appends_suffix() -> None:
+    """Проверяет добавление суффикса _transcript.txt к имени файла."""
+    src = "/tmp/audio.mp3"
+    assert build_output_path(src) == "/tmp/audio_transcript.txt"
+

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -9,4 +9,5 @@ def build_output_path(src: str) -> str:
     :param src: путь к исходному файлу.
     :return: путь к файлу с суффиксом _transcript.
     """
-    return str(Path(src).with_suffix("_transcript.txt"))
+    path = Path(src)
+    return str(path.with_name(f"{path.stem}_transcript.txt"))


### PR DESCRIPTION
## Summary
- Исправлен алгоритм формирования имени выходного файла
- Добавлен модульный тест для проверки добавления суффикса `_transcript.txt`

## Testing
- `pytest tests/test_paths.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8dfddfaa083209529e32e3eea0bff