### PR TITLE
Добавлены тесты для setup_logging

### DIFF
--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,0 +1,27 @@
+"""Тесты для модуля utils.logging_setup."""
+
+from pathlib import Path
+import sys
+import logging
+from unittest.mock import MagicMock
+
+# Добавляем корень проекта в путь поиска модулей.
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from utils.logging_setup import setup_logging
+
+
+def test_setup_logging_default_level(monkeypatch) -> None:
+    """Проверяет использование уровня INFO по умолчанию."""
+    mock_basic = MagicMock()
+    monkeypatch.setattr(logging, "basicConfig", mock_basic)
+    setup_logging()
+    mock_basic.assert_called_once_with(level=logging.INFO, filename=None)
+
+
+def test_setup_logging_with_filename(monkeypatch) -> None:
+    """Проверяет передачу имени файла в basicConfig."""
+    mock_basic = MagicMock()
+    monkeypatch.setattr(logging, "basicConfig", mock_basic)
+    setup_logging(filename="app.log")
+    mock_basic.assert_called_once_with(level=logging.INFO, filename="app.log")


### PR DESCRIPTION
## Summary
- Добавлены тесты, проверяющие использование уровня INFO по умолчанию и передачу имени файла в `setup_logging`.

## Testing
- `pre-commit run --files tests/test_logging_setup.py`
- `pytest tests/test_logging_setup.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8e389679883208dcae1ef0424a0f2