### PR TITLE
Добавлен тест для оркестратора

### DIFF
--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,78 @@
+"""Тесты для модуля core.orchestrator."""
+
+from pathlib import Path
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+# Добавляем корень проекта в путь поиска модулей.
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from core.orchestrator import Orchestrator  # noqa: E402
+from utils.paths import build_output_path  # noqa: E402
+
+
+def test_run_pipeline_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Проверяет успешный запуск пайплайна и порядок вызовов."""
+    src_path = "sample.mp4"
+    audio_path = "sample.wav"
+    text_segments = ["text"]
+    speaker_segments = ["speaker"]
+    merged_lines = ["merged"]
+    expected_path = build_output_path(src_path)
+    call_order: list[str] = []
+
+    media_mock = Mock()
+
+    def validate_side_effect(path: str) -> None:
+        call_order.append("validate")
+        assert path == src_path
+
+    def extract_side_effect(path: str) -> str:
+        call_order.append("extract_audio")
+        assert path == src_path
+        return audio_path
+
+    media_mock.validate.side_effect = validate_side_effect
+    media_mock.extract_audio.side_effect = extract_side_effect
+    monkeypatch.setattr("core.orchestrator.MediaProcessor", Mock(return_value=media_mock))
+
+    def transcribe_side_effect(path: str) -> list[str]:
+        call_order.append("transcribe")
+        assert path == audio_path
+        return text_segments
+
+    def diarize_side_effect(path: str) -> list[str]:
+        call_order.append("diarize")
+        assert path == audio_path
+        return speaker_segments
+
+    def merge_side_effect(ts: list[str], ds: list[str]) -> list[str]:
+        call_order.append("merge")
+        assert ts == text_segments
+        assert ds == speaker_segments
+        return merged_lines
+
+    def export_side_effect(lines: list[str], path: str) -> None:
+        call_order.append("export")
+        assert lines == merged_lines
+        assert path == expected_path
+
+    monkeypatch.setattr("core.orchestrator.transcribe", Mock(side_effect=transcribe_side_effect))
+    monkeypatch.setattr("core.orchestrator.diarize", Mock(side_effect=diarize_side_effect))
+    monkeypatch.setattr("core.orchestrator.merge_results", Mock(side_effect=merge_side_effect))
+    monkeypatch.setattr("core.orchestrator.export_txt", Mock(side_effect=export_side_effect))
+
+    result = Orchestrator().run(src_path)
+
+    assert result == expected_path
+    assert call_order == [
+        "validate",
+        "extract_audio",
+        "transcribe",
+        "diarize",
+        "merge",
+        "export",
+    ]
+


### PR DESCRIPTION
## Summary
- добавить модульные тесты для оркестратора, проверяющие последовательность вызовов

## Testing
- `pytest tests/test_orchestrator.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8e60c249c8320ba63c560b0be0462