### PR TITLE
feat: extract audio via ffmpeg

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -43,14 +43,13 @@ class Orchestrator:
         try:
             media = MediaProcessor()
             media.validate(src_path)
-            audio_path = media.extract_audio(src_path)
+            with media.extract_audio(src_path) as audio_path:
+                text_segments = transcribe(audio_path)
+                speaker_segments = diarize(audio_path)
+                merged_lines = merge_results(text_segments, speaker_segments)
 
-            text_segments = transcribe(audio_path)
-            speaker_segments = diarize(audio_path)
-            merged_lines = merge_results(text_segments, speaker_segments)
-
-            result_path = build_output_path(src_path)
-            export_txt(merged_lines, result_path)
+                result_path = build_output_path(src_path)
+                export_txt(merged_lines, result_path)
 
             if self._on_done:
                 self._on_done(result_path)

--- a/tests/test_media_proc.py
+++ b/tests/test_media_proc.py
@@ -13,7 +13,9 @@ sys.path.append(str(Path(__file__).resolve().parent.parent))
 from core.media_proc import MediaProcessor
 
 
-def test_validate_rejects_unsupported_extension(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_validate_rejects_unsupported_extension(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Проверяет отказ при неподдерживаемом расширении."""
     mp = MediaProcessor()
     # Защищаемся от случайных вызовов внешних команд.
@@ -35,7 +37,28 @@ def test_validate_rejects_long_duration(monkeypatch: pytest.MonkeyPatch) -> None
     """Проверяет отказ при превышении длительности файла."""
     mp = MediaProcessor()
     monkeypatch.setattr(os.path, "getsize", lambda _p: 1)
-    monkeypatch.setattr(MediaProcessor, "_probe_duration", lambda self, _p: mp._MAX_DURATION + 1)
+    monkeypatch.setattr(
+        MediaProcessor, "_probe_duration", lambda self, _p: mp._MAX_DURATION + 1
+    )
     monkeypatch.setattr(subprocess, "run", lambda *a, **k: SimpleNamespace(stdout="0"))
     with pytest.raises(ValueError):
         mp.validate("/tmp/file.mp3")
+
+
+def test_extract_audio_creates_and_cleans(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Проверяет создание и удаление временного файла."""
+    mp = MediaProcessor()
+    created: list[str] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        Path(cmd[-1]).write_bytes(b"0")
+        created.append(cmd[-1])
+        return SimpleNamespace()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with mp.extract_audio("input.mp4") as tmp_path:
+        assert Path(tmp_path).exists()
+        assert tmp_path == created[0]
+
+    assert not Path(created[0]).exists()


### PR DESCRIPTION
## Summary
- use FFmpeg to extract audio into PCM WAV with temporary files
- orchestrate audio processing in context manager to remove temp files
- add tests for extraction cleanup and orchestrator pipeline

## Testing
- `pre-commit run --files core/media_proc.py core/orchestrator.py tests/test_media_proc.py tests/test_orchestrator.py`
- `pytest tests/test_media_proc.py tests/test_orchestrator.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8e7c1c49c83208c6c7400367f1529