### PR TITLE
feat: объединение результатов ASR и диаризации

### DIFF
--- a/core/postprocess.py
+++ b/core/postprocess.py
@@ -2,6 +2,9 @@
 
 from typing import List
 
+from .models import ASRSegment, DiarSegment, Utterance
+from utils.timing import format_ts
+
 
 def merge_results(text: List[str], speakers: List[str]) -> List[str]:
     """Объединяет транскрибацию и диаризацию.
@@ -11,3 +14,53 @@ def merge_results(text: List[str], speakers: List[str]) -> List[str]:
     :return: список готовых строк.
     """
     return [f"{s}: {t}" for s, t in zip(speakers, text)]
+
+
+def _overlap(a_start: float, a_end: float, b_start: float, b_end: float) -> float:
+    """Вычисляет длительность пересечения двух интервалов."""
+    start = max(a_start, b_start)
+    end = min(a_end, b_end)
+    return max(0.0, end - start)
+
+
+def merge(
+    asr_segments: List[ASRSegment], diar_segments: List[DiarSegment]
+) -> List[Utterance]:
+    """Сопоставляет сегменты распознавания со спикерами.
+
+    Для каждого сегмента из ASR выбирается тот спикер диаризации, чей
+    интервал пересекается с ним дольше всего. Если пересечений нет, то
+    используется последний определённый спикер либо ``"unknown"``.
+
+    :param asr_segments: сегменты текста из распознавания.
+    :param diar_segments: сегменты с идентификатором спикера.
+    :return: список готовых реплик.
+    """
+    utterances: List[Utterance] = []
+    last_speaker = "unknown"
+
+    for seg in asr_segments:
+        overlaps = [
+            (_overlap(seg.start, seg.end, d.start, d.end), d.speaker)
+            for d in diar_segments
+            if _overlap(seg.start, seg.end, d.start, d.end) > 0
+        ]
+
+        if overlaps:
+            # При равенстве длительности берётся первый по времени сегмент.
+            _, speaker = max(overlaps, key=lambda item: item[0])
+            last_speaker = speaker
+        else:
+            speaker = last_speaker
+
+        timespan = f"[{format_ts(seg.start)} — {format_ts(seg.end)}]"
+        utterances.append(
+            Utterance(
+                timespan=timespan,
+                speaker=speaker,
+                text=seg.text,
+                words=seg.text.split(),
+            )
+        )
+
+    return utterances

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -6,7 +6,9 @@ import sys
 # Добавляем корень проекта в путь поиска модулей.
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 
-from core.postprocess import merge_results
+from core.postprocess import merge, merge_results
+from core.models import ASRSegment, DiarSegment, Utterance
+from utils.timing import format_ts
 
 
 def test_merge_results_equal_lengths() -> None:
@@ -28,3 +30,33 @@ def test_merge_results_ignores_extra_items() -> None:
         "Спикер 2: Два",
     ]
 
+
+def test_merge_assigns_speaker_by_longest_overlap() -> None:
+    """Выбирает спикера с наибольшим пересечением интервалов."""
+    asr = [ASRSegment(start=0.0, end=10.0, text="фраза")]
+    diar = [
+        DiarSegment(start=0.0, end=4.0, speaker="A"),
+        DiarSegment(start=4.0, end=10.0, speaker="B"),
+    ]
+
+    result = merge(asr, diar)
+    assert result == [
+        Utterance(
+            timespan=f"[{format_ts(0.0)} — {format_ts(10.0)}]",
+            speaker="B",
+            text="фраза",
+            words=["фраза"],
+        )
+    ]
+
+
+def test_merge_prefers_first_on_equal_overlap() -> None:
+    """При равном пересечении выбирается первый по времени спикер."""
+    asr = [ASRSegment(start=2.0, end=8.0, text="текст")]
+    diar = [
+        DiarSegment(start=0.0, end=5.0, speaker="X"),
+        DiarSegment(start=5.0, end=10.0, speaker="Y"),
+    ]
+
+    result = merge(asr, diar)
+    assert result[0].speaker == "X"


### PR DESCRIPTION
## Summary
- добавить функцию `merge` для сопоставления сегментов распознавания и диаризации
- покрыть пересечения тестами

## Testing
- `pre-commit run --files core/postprocess.py tests/test_postprocess.py`
- `pytest tests/test_postprocess.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa172457b8832093770122d8027b66