### PR TITLE
feat: implement text transcript export with timecodes

### DIFF
--- a/core/export_txt.py
+++ b/core/export_txt.py
@@ -2,6 +2,9 @@
 
 from typing import List
 
+from .models import Utterance
+from utils.paths import build_output_path
+
 
 def export_txt(lines: List[str], path: str) -> str:
     """Сохраняет строки в файл .txt.
@@ -13,3 +16,16 @@ def export_txt(lines: List[str], path: str) -> str:
     with open(path, "w", encoding="utf-8") as file:
         file.write("\n".join(lines))
     return path
+
+
+def save_txt(utterances: List[Utterance], base_path: str) -> str:
+    """Формирует строки и сохраняет реплики в файл .txt.
+
+    :param utterances: список готовых реплик.
+    :param base_path: путь к исходному файлу, на основе которого создаётся
+        имя результирующего файла.
+    :return: путь к созданному файлу.
+    """
+    lines = [f"{u.timespan} {u.speaker}: {u.text}" for u in utterances]
+    path = build_output_path(base_path)
+    return export_txt(lines, path)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -6,9 +6,10 @@ import sys
 # Добавляем корень проекта в путь поиска модулей.
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 
-from core.export_txt import export_txt
+from core.export_txt import export_txt, save_txt
 from core.export_srt import export_srt
 from core.export_md import export_md
+from core.models import Utterance
 
 
 def test_export_txt_writes_file(tmp_path) -> None:
@@ -33,3 +34,30 @@ def test_export_md_writes_file(tmp_path) -> None:
     path = tmp_path / "out.md"
     export_md(lines, str(path))
     assert path.read_text(encoding="utf-8") == "\n".join(lines)
+
+
+def test_save_txt_formats_times_and_utf8(tmp_path) -> None:
+    """Проверяет форматирование таймкодов и кодировку UTF-8."""
+    utterances = [
+        Utterance(
+            timespan="[00:00:01 — 00:00:02]",
+            speaker="Спикер 1",
+            text="Привет",
+            words=["Привет"],
+        ),
+        Utterance(
+            timespan="[00:00:03 — 00:00:04]",
+            speaker="Спикер 2",
+            text="Пока",
+            words=["Пока"],
+        ),
+    ]
+    src = tmp_path / "meeting.wav"
+    result_path = save_txt(utterances, str(src))
+    expected_path = tmp_path / "meeting_transcript.txt"
+    assert result_path == str(expected_path)
+    content = expected_path.read_text(encoding="utf-8")
+    assert content == (
+        "[00:00:01 — 00:00:02] Спикер 1: Привет\n"
+        "[00:00:03 — 00:00:04] Спикер 2: Пока"
+    )


### PR DESCRIPTION
## Summary
- add `save_txt` to format utterances with timecodes and save transcripts
- cover UTF-8 export and timestamp formatting with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa1e40a6048320874b6fe987605c9b