### PR TITLE
feat: add global logging and GUI error handler

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,16 +1,24 @@
 """Точка входа приложения."""
 
+import logging
+
 from PyQt5.QtWidgets import QApplication
 
 from core.orchestrator import Orchestrator
 from gui.window import MainWindow
+from utils.logging_setup import setup_logging
+
+
+logger = logging.getLogger(__name__)
 
 
 def main() -> None:
     """Создаёт GUI и связывает его с оркестратором."""
     app = QApplication([])
     window = MainWindow()
-    orchestrator = Orchestrator(on_done=window.set_done, on_error=window.set_error)
+    setup_logging(filename="transcriber.log", gui_callback=window.set_error)
+    logger.info("Приложение запущено")
+    orchestrator = Orchestrator(on_done=window.set_done)
     window.file_dropped.connect(orchestrator.run)
     window.show()
     app.exec_()

--- a/core/asr_whisper.py
+++ b/core/asr_whisper.py
@@ -1,7 +1,8 @@
 """Модуль транскрибации."""
 
-from typing import List
+import logging
 import os
+from typing import List
 
 from dotenv import load_dotenv
 
@@ -13,6 +14,9 @@ except Exception:  # noqa: BLE001
 import whisper
 
 from core.models import ASRSegment
+
+
+logger = logging.getLogger(__name__)
 
 
 load_dotenv()
@@ -32,6 +36,7 @@ def transcribe(wav_path: str, model: str = "small") -> List[ASRSegment]:
     :param model: название модели Whisper (по умолчанию ``small``).
     :return: список сегментов с началом, концом и текстом.
     """
+    logger.info("Запуск распознавания модели %s", model)
     asr = whisper.load_model(model)
     result = asr.transcribe(wav_path)
     return [

--- a/core/diarization.py
+++ b/core/diarization.py
@@ -1,10 +1,15 @@
 """Модуль диаризации."""
 
-from typing import List
+import logging
 import wave
+from typing import List
+
 import numpy as np
 
 from .models import DiarSegment
+
+
+logger = logging.getLogger(__name__)
 
 
 def _dominant_freq(samples: np.ndarray, rate: int) -> float:
@@ -20,6 +25,7 @@ def diarize(path: str) -> List[DiarSegment]:
     :param path: путь к wav-файлу.
     :return: список сегментов с идентификатором спикера.
     """
+    logger.info("Диаризация файла %s", path)
     with wave.open(path, "rb") as wav:
         rate = wav.getframerate()
         frames = wav.readframes(wav.getnframes())

--- a/core/export_md.py
+++ b/core/export_md.py
@@ -1,6 +1,10 @@
 """Экспорт в формат Markdown."""
 
+import logging
 from typing import List
+
+
+logger = logging.getLogger(__name__)
 
 
 def export_md(lines: List[str], path: str) -> str:
@@ -10,6 +14,7 @@ def export_md(lines: List[str], path: str) -> str:
     :param path: путь к результирующему файлу.
     :return: путь к созданному файлу.
     """
+    logger.info("Сохранение Markdown в %s", path)
     with open(path, "w", encoding="utf-8") as file:
         file.write("\n".join(lines))
     return path

--- a/core/export_srt.py
+++ b/core/export_srt.py
@@ -1,6 +1,10 @@
 """Экспорт в формат SRT."""
 
+import logging
 from typing import List
+
+
+logger = logging.getLogger(__name__)
 
 
 def export_srt(lines: List[str], path: str) -> str:
@@ -10,6 +14,7 @@ def export_srt(lines: List[str], path: str) -> str:
     :param path: путь к результирующему файлу.
     :return: путь к созданному файлу.
     """
+    logger.info("Сохранение SRT в %s", path)
     with open(path, "w", encoding="utf-8") as file:
         file.write("\n".join(lines))
     return path

--- a/core/export_txt.py
+++ b/core/export_txt.py
@@ -1,9 +1,13 @@
 """Экспорт в текстовый файл."""
 
+import logging
 from typing import List
 
 from .models import Utterance
 from utils.paths import build_output_path
+
+
+logger = logging.getLogger(__name__)
 
 
 def export_txt(lines: List[str], path: str) -> str:
@@ -13,6 +17,7 @@ def export_txt(lines: List[str], path: str) -> str:
     :param path: путь к результирующему файлу.
     :return: путь к созданному файлу.
     """
+    logger.info("Сохранение текста в %s", path)
     with open(path, "w", encoding="utf-8") as file:
         file.write("\n".join(lines))
     return path

--- a/core/media_proc.py
+++ b/core/media_proc.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import subprocess
 from contextlib import contextmanager
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Iterator
+
+
+logger = logging.getLogger(__name__)
 
 
 class MediaProcessor:
@@ -47,6 +51,7 @@ class MediaProcessor:
         :param path: путь к медиафайлу.
         :raises ValueError: при нарушении ограничений.
         """
+        logger.debug("Проверка файла %s", path)
         extension = Path(path).suffix.lower()
         if extension not in self._SUPPORTED_EXTENSIONS:
             raise ValueError("Недопустимый формат файла")
@@ -81,7 +86,9 @@ class MediaProcessor:
                 text=True,
                 check=True,
             )
-            return float(result.stdout.strip())
+            duration = float(result.stdout.strip())
+            logger.debug("Длительность файла %s секунд", duration)
+            return duration
         except (FileNotFoundError, subprocess.SubprocessError, ValueError) as error:
             raise ValueError("Не удалось определить длительность файла") from error
 
@@ -107,6 +114,7 @@ class MediaProcessor:
             "s16",
             tmp_path,
         ]
+        logger.info("Извлечение аудио из %s", path)
         try:
             subprocess.run(
                 cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
@@ -115,5 +123,6 @@ class MediaProcessor:
         finally:
             try:
                 os.remove(tmp_path)
+                logger.debug("Удалён временный файл %s", tmp_path)
             except OSError:
                 pass

--- a/core/models.py
+++ b/core/models.py
@@ -1,7 +1,11 @@
 """Дата-классы проекта."""
 
+import logging
 from dataclasses import dataclass
 from typing import List
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass

--- a/core/postprocess.py
+++ b/core/postprocess.py
@@ -1,9 +1,13 @@
 """Модуль постобработки."""
 
+import logging
 from typing import List
 
 from .models import ASRSegment, DiarSegment, Utterance
 from utils.timing import format_ts
+
+
+logger = logging.getLogger(__name__)
 
 
 def merge_results(text: List[str], speakers: List[str]) -> List[str]:
@@ -13,6 +17,7 @@ def merge_results(text: List[str], speakers: List[str]) -> List[str]:
     :param speakers: список спикеров.
     :return: список готовых строк.
     """
+    logger.debug("Слияние %d строк", len(text))
     return [f"{s}: {t}" for s, t in zip(speakers, text)]
 
 
@@ -36,6 +41,11 @@ def merge(
     :param diar_segments: сегменты с идентификатором спикера.
     :return: список готовых реплик.
     """
+    logger.debug(
+        "Сопоставление %d сегментов ASR и %d сегментов диаризации",
+        len(asr_segments),
+        len(diar_segments),
+    )
     utterances: List[Utterance] = []
     last_speaker = "unknown"
 

--- a/gui/messages.py
+++ b/gui/messages.py
@@ -1,5 +1,10 @@
 """Сообщения интерфейса."""
 
+import logging
+
+
+logger = logging.getLogger(__name__)
+
 READY_MESSAGE = "Загрузите файл для обработки"
 PROCESSING_MESSAGE = "Идёт обработка..."
 DONE_MESSAGE = "Обработка завершена"

--- a/gui/window.py
+++ b/gui/window.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Optional
 
 from PyQt5.QtCore import Qt, pyqtSignal
@@ -9,6 +10,9 @@ from PyQt5.QtGui import QDragEnterEvent, QDropEvent
 from PyQt5.QtWidgets import QLabel, QVBoxLayout, QWidget
 
 from gui import messages
+
+
+logger = logging.getLogger(__name__)
 
 
 class MainWindow(QWidget):
@@ -74,5 +78,6 @@ class MainWindow(QWidget):
         urls = event.mimeData().urls()
         if urls:
             file_path = urls[0].toLocalFile()
+            logger.info("Получен файл %s", file_path)
             self.set_processing()
             self.file_dropped.emit(file_path)

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -3,25 +3,26 @@
 from pathlib import Path
 import sys
 import logging
-from unittest.mock import MagicMock
 
 # Добавляем корень проекта в путь поиска модулей.
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 
-from utils.logging_setup import setup_logging
+from utils.logging_setup import setup_logging  # noqa: E402
 
 
-def test_setup_logging_default_level(monkeypatch) -> None:
-    """Проверяет использование уровня INFO по умолчанию."""
-    mock_basic = MagicMock()
-    monkeypatch.setattr(logging, "basicConfig", mock_basic)
-    setup_logging()
-    mock_basic.assert_called_once_with(level=logging.INFO, filename=None)
+def test_setup_logging_adds_handlers(tmp_path) -> None:
+    """Проверяет добавление файлового и консольного обработчиков."""
+    log_path = tmp_path / "app.log"
+    setup_logging(filename=str(log_path))
+    root = logging.getLogger()
+    assert any(isinstance(h, logging.StreamHandler) for h in root.handlers)
+    assert any(isinstance(h, logging.FileHandler) for h in root.handlers)
 
 
-def test_setup_logging_with_filename(monkeypatch) -> None:
-    """Проверяет передачу имени файла в basicConfig."""
-    mock_basic = MagicMock()
-    monkeypatch.setattr(logging, "basicConfig", mock_basic)
-    setup_logging(filename="app.log")
-    mock_basic.assert_called_once_with(level=logging.INFO, filename="app.log")
+def test_gui_handler_receives_error(tmp_path) -> None:
+    """Проверяет отправку сообщения в GUI колбэк при ошибке."""
+    received: list[str] = []
+    setup_logging(gui_callback=received.append)
+    logger = logging.getLogger("test")
+    logger.error("boom")
+    assert received and "boom" in received[0]

--- a/utils/logging_setup.py
+++ b/utils/logging_setup.py
@@ -1,13 +1,55 @@
-"""Настройка логгирования."""
+"""Настройка логирования в приложении."""
+
+from __future__ import annotations
 
 import logging
-from typing import Optional
+import sys
+from typing import Callable, Optional
 
 
-def setup_logging(level: int = logging.INFO, filename: Optional[str] = None) -> None:
-    """Настраивает логирование.
+class GuiLogHandler(logging.Handler):
+    """Передаёт сообщения об ошибках в GUI."""
 
-    :param level: уровень логгирования.
-    :param filename: файл для записи логов.
+    def __init__(self, callback: Callable[[str], None]) -> None:
+        super().__init__(level=logging.ERROR)
+        self._callback = callback
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """Отправляет сообщение в callback."""
+        msg = self.format(record)
+        self._callback(msg)
+
+
+def setup_logging(
+    level: int = logging.INFO,
+    filename: Optional[str] = None,
+    gui_callback: Optional[Callable[[str], None]] = None,
+) -> None:
+    """Настраивает вывод логов в файл, консоль и GUI.
+
+    :param level: уровень логирования.
+    :param filename: путь к файлу логов.
+    :param gui_callback: функция для отображения ошибок в интерфейсе.
     """
-    logging.basicConfig(level=level, filename=filename)
+    root = logging.getLogger()
+    root.setLevel(level)
+    root.handlers.clear()
+
+    formatter = logging.Formatter(
+        "%(asctime)s %(levelname)s %(name)s: %(message)s"
+    )
+
+    stream = logging.StreamHandler(sys.stdout)
+    stream.setFormatter(formatter)
+    root.addHandler(stream)
+
+    if filename:
+        file_handler = logging.FileHandler(filename, encoding="utf-8")
+        file_handler.setFormatter(formatter)
+        root.addHandler(file_handler)
+
+    if gui_callback:
+        gui_handler = GuiLogHandler(gui_callback)
+        gui_handler.setFormatter(formatter)
+        root.addHandler(gui_handler)
+

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -1,6 +1,10 @@
 """Утилиты работы с путями."""
 
+import logging
 from pathlib import Path
+
+
+logger = logging.getLogger(__name__)
 
 
 def build_output_path(src: str) -> str:
@@ -10,4 +14,6 @@ def build_output_path(src: str) -> str:
     :return: путь к файлу с суффиксом _transcript.
     """
     path = Path(src)
-    return str(path.with_name(f"{path.stem}_transcript.txt"))
+    result = path.with_name(f"{path.stem}_transcript.txt")
+    logger.debug("Итоговый путь %s", result)
+    return str(result)

--- a/utils/timing.py
+++ b/utils/timing.py
@@ -1,5 +1,10 @@
 """Утилиты форматирования времени."""
 
+import logging
+
+
+logger = logging.getLogger(__name__)
+
 
 def format_ts(seconds: float) -> str:
     """Форматирует секунды в строку HH:MM:SS.
@@ -10,4 +15,6 @@ def format_ts(seconds: float) -> str:
     hours = int(seconds // 3600)
     minutes = int((seconds % 3600) // 60)
     secs = int(seconds % 60)
-    return f"{hours:02d}:{minutes:02d}:{secs:02d}"
+    result = f"{hours:02d}:{minutes:02d}:{secs:02d}"
+    logger.debug("Форматированное время %s", result)
+    return result


### PR DESCRIPTION
## Summary
- configure logging to write to both file and stdout; add GUI handler for errors
- integrate logger across modules and log processing stages
- show GUI error messages on orchestrator errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa2186b21c8320b964b3e15134cf38