### PR TITLE
core: use pyannote for diarization

### DIFF
--- a/tests/test_diarization.py
+++ b/tests/test_diarization.py
@@ -3,38 +3,52 @@
 from pathlib import Path
 import sys
 import wave
+from unittest.mock import patch
+
 import numpy as np
 import pytest
+from pyannote.core import Annotation, Segment
 
 # Добавляем корень проекта в путь поиска модулей.
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 
-from core.diarization import diarize
+import core.diarization as dia
 
 
-def _write_wave(path: Path, data: np.ndarray, rate: int = 16000) -> None:
-    """Сохраняет массив в wav-файл."""
+def _write_silence(path: Path, duration: float, rate: int = 16000) -> None:
+    """Создаёт wav-файл с тишиной."""
+
+    data = np.zeros(int(rate * duration), dtype=np.int16)
     with wave.open(str(path), "wb") as wav:
         wav.setnchannels(1)
         wav.setsampwidth(2)
         wav.setframerate(rate)
-        wav.writeframes((data * 32767).astype(np.int16).tobytes())
+        wav.writeframes(data.tobytes())
 
 
-def _sine(freq: float, duration: float, rate: int = 16000) -> np.ndarray:
-    """Генерирует синус с заданной частотой."""
-    t = np.linspace(0, duration, int(rate * duration), False)
-    return 0.5 * np.sin(2 * np.pi * freq * t)
+class DummyPipeline:
+    """Пайплайн, возвращающий два сегмента."""
+
+    def __call__(self, path: str) -> Annotation:  # pragma: no cover
+        annotation = Annotation()
+        annotation[Segment(0, 1)] = "speaker_0"
+        annotation[Segment(1, 2)] = "speaker_1"
+        return annotation
 
 
-def test_diarize_two_speakers(tmp_path: Path) -> None:
-    """Проверяет выделение двух спикеров в записи."""
-    audio = np.concatenate([_sine(440, 1), _sine(660, 1)])
-    path = tmp_path / "two.wav"
-    _write_wave(path, audio)
-    segments = diarize(str(path))
+@patch(
+    "core.diarization.Pipeline.from_pretrained",
+    return_value=DummyPipeline(),
+)
+def test_diarize_two_speakers(mock_pipeline, tmp_path: Path) -> None:
+    """Проверяет получение сегментов от пайплайна pyannote."""
+
+    dia._PIPELINE = None
+    path = tmp_path / "audio.wav"
+    _write_silence(path, 2)
+    segments = dia.diarize(str(path))
     assert [s.speaker for s in segments] == ["speaker_0", "speaker_1"]
-    assert pytest.approx(0, abs=0.05) == segments[0].start
-    assert pytest.approx(1, abs=0.05) == segments[0].end
-    assert pytest.approx(1, abs=0.05) == segments[1].start
-    assert pytest.approx(2, abs=0.05) == segments[1].end
+    assert pytest.approx(0, abs=0.01) == segments[0].start
+    assert pytest.approx(1, abs=0.01) == segments[0].end
+    assert pytest.approx(1, abs=0.01) == segments[1].start
+    assert pytest.approx(2, abs=0.01) == segments[1].end


### PR DESCRIPTION
## Summary
- replace naive diarization with pyannote.audio pipeline and HF token loading
- mock pyannote pipeline in tests

## Testing
- `pre-commit run --files core/diarization.py tests/test_diarization.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa42e294f88320bfa0663e4f2aa87d