### PR TITLE
Fix transcript path resolution to ensure file appears

### DIFF
--- a/core/export_txt.py
+++ b/core/export_txt.py
@@ -1,6 +1,7 @@
 """Экспорт в текстовый файл."""
 
 import logging
+from pathlib import Path
 from typing import List
 
 from .models import Utterance
@@ -17,10 +18,11 @@ def export_txt(lines: List[str], path: str) -> str:
     :param path: путь к результирующему файлу.
     :return: путь к созданному файлу.
     """
-    logger.info("Сохранение текста в %s", path)
-    with open(path, "w", encoding="utf-8") as file:
-        file.write("\n".join(lines))
-    return path
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    logger.info("Сохранение текста в %s", output_path)
+    output_path.write_text("\n".join(lines), encoding="utf-8")
+    return str(output_path)
 
 
 def save_txt(utterances: List[Utterance], base_path: str) -> str:

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -20,6 +20,14 @@ def test_export_txt_writes_file(tmp_path) -> None:
     assert path.read_text(encoding="utf-8") == "\n".join(lines)
 
 
+def test_export_txt_creates_parent_dirs(tmp_path) -> None:
+    """Создаёт недостающие директории перед записью."""
+    lines = ["строка"]
+    path = tmp_path / "nested" / "out.txt"
+    export_txt(lines, str(path))
+    assert path.read_text(encoding="utf-8") == "\n".join(lines)
+
+
 def test_export_srt_writes_file(tmp_path) -> None:
     """Проверяет запись строк в файл .srt."""
     lines = ["первая", "вторая"]

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -15,3 +15,12 @@ def test_build_output_path_appends_suffix() -> None:
     expected = src.with_name(f"{src.stem}_transcript.txt")
     # Нормализуем обе стороны как Path, чтобы абстрагироваться от разделителей
     assert Path(build_output_path(str(src))) == expected
+
+
+def test_build_output_path_is_absolute(tmp_path, monkeypatch) -> None:
+    """Убеждается, что возвращается абсолютный путь."""
+    monkeypatch.chdir(tmp_path)
+    src = Path("meeting.mp3")
+    result = Path(build_output_path(str(src)))
+    assert result.is_absolute()
+    assert result == (tmp_path / "meeting_transcript.txt").resolve()

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -8,12 +8,12 @@ logger = logging.getLogger(__name__)
 
 
 def build_output_path(src: str) -> str:
-    """Создаёт путь для результирующего файла.
+    """Создаёт абсолютный путь для результирующего файла.
 
     :param src: путь к исходному файлу.
-    :return: путь к файлу с суффиксом _transcript.
+    :return: путь к файлу с суффиксом _transcript.txt.
     """
-    path = Path(src)
+    path = Path(src).expanduser().resolve()
     result = path.with_name(f"{path.stem}_transcript.txt")
     logger.debug("Итоговый путь %s", result)
     return str(result)


### PR DESCRIPTION
## Summary
- resolve input media path to absolute when building transcript output path
- create parent directory before writing transcript file
- cover path handling with new tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa5402a390832094fc87a084796eef