### PR TITLE
Ensure transcript is written near source media

### DIFF
--- a/core/export_txt.py
+++ b/core/export_txt.py
@@ -1,6 +1,7 @@
 """Экспорт в текстовый файл."""
 
 import logging
+from pathlib import Path
 from typing import List
 
 from .models import Utterance
@@ -17,10 +18,13 @@ def export_txt(lines: List[str], path: str) -> str:
     :param path: путь к результирующему файлу.
     :return: путь к созданному файлу.
     """
-    logger.info("Сохранение текста в %s", path)
-    with open(path, "w", encoding="utf-8") as file:
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    logger.info("Сохранение текста в %s", output_path)
+    with output_path.open("w", encoding="utf-8", newline="\n") as file:
         file.write("\n".join(lines))
-    return path
+        file.flush()
+    return str(output_path)
 
 
 def save_txt(utterances: List[Utterance], base_path: str) -> str:

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -20,6 +20,14 @@ def test_export_txt_writes_file(tmp_path) -> None:
     assert path.read_text(encoding="utf-8") == "\n".join(lines)
 
 
+def test_export_txt_creates_parent_dirs(tmp_path) -> None:
+    """Создаёт недостающие директории перед записью."""
+    lines = ["строка"]
+    path = tmp_path / "nested" / "out.txt"
+    export_txt(lines, str(path))
+    assert path.read_text(encoding="utf-8") == "\n".join(lines)
+
+
 def test_export_srt_writes_file(tmp_path) -> None:
     """Проверяет запись строк в файл .srt."""
     lines = ["первая", "вторая"]
@@ -61,3 +69,23 @@ def test_save_txt_formats_times_and_utf8(tmp_path) -> None:
         "[00:00:01 — 00:00:02] Спикер 1: Привет\n"
         "[00:00:03 — 00:00:04] Спикер 2: Пока"
     )
+
+
+def test_save_txt_creates_file_near_source(tmp_path) -> None:
+    """Сохраняет итоговый файл рядом с исходным."""
+    src_dir = tmp_path / "папка с пробелом"
+    src_dir.mkdir()
+    src = src_dir / "видео.mp4"
+    src.write_text("", encoding="utf-8")
+    utterances = [
+        Utterance(
+            timespan="[00:00:00 — 00:00:01]",
+            speaker="Спикер 1",
+            text="Привет",
+            words=["Привет"],
+        )
+    ]
+    result = save_txt(utterances, str(src))
+    expected = src_dir / "видео_transcript.txt"
+    assert result == str(expected)
+    assert expected.exists()

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -15,3 +15,12 @@ def test_build_output_path_appends_suffix() -> None:
     expected = src.with_name(f"{src.stem}_transcript.txt")
     # Нормализуем обе стороны как Path, чтобы абстрагироваться от разделителей
     assert Path(build_output_path(str(src))) == expected
+
+
+def test_build_output_path_is_absolute(tmp_path, monkeypatch) -> None:
+    """Убеждается, что возвращается абсолютный путь."""
+    monkeypatch.chdir(tmp_path)
+    src = Path("meeting.mp3")
+    result = Path(build_output_path(str(src)))
+    assert result.is_absolute()
+    assert result == (tmp_path / "meeting_transcript.txt").resolve()

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -8,12 +8,14 @@ logger = logging.getLogger(__name__)
 
 
 def build_output_path(src: str) -> str:
-    """Создаёт путь для результирующего файла.
+    """Создаёт абсолютный путь для результирующего файла.
 
     :param src: путь к исходному файлу.
-    :return: путь к файлу с суффиксом _transcript.
+    :return: путь к файлу с суффиксом _transcript.txt.
     """
-    path = Path(src)
+    path = Path(src).expanduser()
+    if not path.is_absolute():
+        path = path.absolute()
     result = path.with_name(f"{path.stem}_transcript.txt")
     logger.debug("Итоговый путь %s", result)
     return str(result)


### PR DESCRIPTION
## Summary
- write transcript using explicit file handle and flush to guarantee creation
- build output path using absolute path without resolving symlinks
- cover unicode/space source paths in export tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa5402a390832094fc87a084796eef