### PR TITLE
fix: include Lightning data files in PyInstaller build

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ python build.py
 dist\\transcriber.exe
 ```
 
+Скрипт `build.py` добавляет в сборку служебные данные пакетов
+`lightning_fabric` и `pytorch_lightning`. Это предотвращает ошибку
+`FileNotFoundError: version.info` при запуске собранного `exe`. Если
+используете `pyinstaller` вручную, добавьте флаги
+`--collect-data lightning_fabric --collect-data pytorch_lightning`.
+
 ## Обновление документации
 
 Этот файл необходимо актуализировать при добавлении новой функциональности.

--- a/build.py
+++ b/build.py
@@ -16,6 +16,12 @@ def build() -> None:
             "--onefile",
             "--noconsole",
             "--clean",
+            # Добавляем служебные файлы библиотек Lightning,
+            # чтобы exe не падал с FileNotFoundError.
+            "--collect-data",
+            "lightning_fabric",
+            "--collect-data",
+            "pytorch_lightning",
         ]
     )
 


### PR DESCRIPTION
## Summary
- include data files from lightning_fabric and pytorch_lightning in build script to avoid version.info error in PyInstaller exe
- document Lightning data collection for manual builds

## Testing
- `pytest -q` *(fails: KeyboardInterrupt: tests hang, missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_68aa7028d21c8320a0954a2b9df63841